### PR TITLE
Use capitalised `Root`

### DIFF
--- a/pdflayers/utils.py
+++ b/pdflayers/utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def set_layer_visibility(pdf, layers_to_show):
     """Set visibility of layers."""
     try:
-        ocgs = pdf.root.OCProperties.OCGs
+        ocgs = pdf.Root.OCProperties.OCGs
     except (AttributeError, KeyError):
         logger.error("Unable to locate layers in PDF.")
         sys.exit(1)
@@ -29,7 +29,7 @@ def set_layer_visibility(pdf, layers_to_show):
         Order=ocgs,
     )
 
-    pdf.root.OCProperties = pikepdf.Dictionary(
+    pdf.Root.OCProperties = pikepdf.Dictionary(
         D=ocgs_config,
         OCGs=ocgs,
     )


### PR DESCRIPTION
Lower-case `root` is deprecated and doesn't work with newer versions of pikepdf.